### PR TITLE
Re-introduce Python 3.5 with only f-strings removal

### DIFF
--- a/torchsummary/formatting.py
+++ b/torchsummary/formatting.py
@@ -47,7 +47,7 @@ class FormattingOptions:
     def format_row(self, layer_name: str, row_values: Dict[str, str]) -> str:
         """ Get the string representation of a single layer of the model. """
         info_to_use = [row_values.get(row_type, "") for row_type in self.col_names]
-        new_line = f"{layer_name:<{self.layer_name_width}} "
+        new_line = "{:<{}} ".format((layer_name), (self.layer_name_width))
         for info in info_to_use:
-            new_line += f"{info:<{self.col_width}} "
+            new_line += "{:<{}} ".format((info), (self.col_width))
         return new_line.rstrip() + "\n"

--- a/torchsummary/layer_info.py
+++ b/torchsummary/layer_info.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, List, Sequence, Union
 
 import numpy as np
@@ -17,20 +15,20 @@ class LayerInfo:
         self.layer_id = id(module)
         self.module = module
         self.class_name = str(module.__class__).split(".")[-1].split("'")[0]
-        self.inner_layers: Dict[str, List[int]] = {}
+        self.inner_layers = {}  # type: Dict[str, List[int]]
         self.depth = depth
         self.depth_index = depth_index
 
         # Statistics
         self.trainable = True
         self.is_recursive = False
-        self.output_size: List[Union[int, Sequence[Any], torch.Size]] = []
-        self.kernel_size: List[int] = []
+        self.output_size = []  # type: List[Union[int, Sequence[Any], torch.Size]]
+        self.kernel_size = []  # type: List[int]
         self.num_params = 0
         self.macs = 0
 
     def __repr__(self) -> str:
-        return f"{self.class_name}: {self.depth}-{self.depth_index}"
+        return "{}: {}-{}".format((self.class_name), (self.depth), (self.depth_index))
 
     def calculate_output_size(self, outputs: DETECTED_OUTPUT_TYPES, batch_dim: int) -> None:
         """ Set output_size using the model's outputs. """
@@ -53,7 +51,7 @@ class LayerInfo:
             self.output_size[batch_dim] = -1
 
         else:
-            raise TypeError(f"Model contains a layer with an unsupported output type: {outputs}")
+            raise TypeError("Model contains a layer with an unsupported output type: %s" % outputs)
 
     def calculate_num_params(self) -> None:
         """ Set num_params using the module's parameters.  """
@@ -79,7 +77,7 @@ class LayerInfo:
                 self.inner_layers[name] = list(param.size())
                 self.macs += param.nelement()
 
-    def check_recursive(self, summary_list: List[LayerInfo]) -> None:
+    def check_recursive(self, summary_list: "List[LayerInfo]") -> None:
         """ if the current module is already-used, mark as (recursive).
         Must check before adding line to the summary. """
         if list(self.module.named_parameters()):
@@ -90,7 +88,7 @@ class LayerInfo:
     def macs_to_str(self, reached_max_depth: bool) -> str:
         """ Convert MACs to string. """
         if self.num_params > 0 and (reached_max_depth or not any(self.module.children())):
-            return f"{self.macs:,}"
+            return "{:,}".format((self.macs))
         return "--"
 
     def num_params_to_str(self, reached_max_depth: bool = False) -> str:
@@ -99,9 +97,9 @@ class LayerInfo:
         if self.is_recursive:
             return "(recursive)"
         if self.num_params > 0:
-            param_count_str = f"{self.num_params:,}"
+            param_count_str = "{:,}".format((self.num_params))
             if reached_max_depth or not any(self.module.children()):
                 if not self.trainable:
-                    return f"({param_count_str})"
+                    return "({})".format((param_count_str))
                 return param_count_str
         return "--"

--- a/torchsummary/model_statistics.py
+++ b/torchsummary/model_statistics.py
@@ -66,22 +66,39 @@ class ModelStatistics:
         total_size = self.total_input + self.total_output + self.total_params
         width = self.formatting.get_total_width()
         summary_str = (
-            f"{'-' * width}\n"
-            f"{header_row}"
-            f"{'=' * width}\n"
-            f"{layer_rows}"
-            f"{'=' * width}\n"
-            f"Total params: {self.total_params:,}\n"
-            f"Trainable params: {self.trainable_params:,}\n"
-            f"Non-trainable params: {self.total_params - self.trainable_params:,}\n"
-            f"Total mult-adds ({'G' if self.total_mult_adds >= 1e9 else 'M'}): "
-            f"{self.to_readable(self.total_mult_adds):0.2f}\n"
-            f"{'-' * width}\n"
-            f"Input size (MB): {self.to_bytes(self.total_input):0.2f}\n"
-            f"Forward/backward pass size (MB): {self.to_bytes(self.total_output):0.2f}\n"
-            f"Params size (MB): {self.to_bytes(self.total_params):0.2f}\n"
-            f"Estimated Total Size (MB): {self.to_bytes(total_size):0.2f}\n"
-            f"{'-' * width}"
+            "{}\n"
+            "{}"
+            "{}\n"
+            "{}"
+            "{}\n"
+            "Total params: {:,}\n"
+            "Trainable params: {:,}\n"
+            "Non-trainable params: {:,}\n"
+            "Total mult-adds ({}): "
+            "{:0.2f}\n"
+            "{}\n"
+            "Input size (MB): {:0.2f}\n"
+            "Forward/backward pass size (MB): {:0.2f}\n"
+            "Params size (MB): {:0.2f}\n"
+            "Estimated Total Size (MB): {:0.2f}\n"
+            "{}".format(
+                ("-" * width),
+                (header_row),
+                ("=" * width),
+                (layer_rows),
+                ("=" * width),
+                (self.total_params),
+                (self.trainable_params),
+                (self.total_params - self.trainable_params),
+                ('G' if self.total_mult_adds >= 1e9 else 'M'),
+                (self.to_readable(self.total_mult_adds)),
+                ("-" * width),
+                (self.to_bytes(self.total_input)),
+                (self.to_bytes(self.total_output)),
+                (self.to_bytes(self.total_params)),
+                (self.to_bytes(total_size)),
+                ("-" * width),
+            )
         )
         return summary_str
 

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -27,7 +27,7 @@ def summary(
     device: Optional[torch.device] = None,
     dtypes: Optional[List[torch.dtype]] = None,
     verbose: int = 1,
-    **kwargs: Any,
+    **kwargs: Any
 ) -> ModelStatistics:
     """
     Summarize the given PyTorch model. Summarized information includes:
@@ -61,9 +61,9 @@ def summary(
         args, kwargs: Other arguments used in `model.forward` function.
     """
     assert verbose in (0, 1, 2)
-    summary_list: List[LayerInfo] = []
-    hooks: List[RemovableHandle] = []
-    idx: Dict[int, int] = {}
+    summary_list = []  # type: List[LayerInfo]
+    hooks = []  # type: List[RemovableHandle]
+    idx = {}  # type: Dict[int, int]
     apply_hooks(model, model, depth, summary_list, hooks, idx, batch_dim)
 
     if device is None:
@@ -99,7 +99,9 @@ def summary(
         with torch.no_grad():
             _ = model.to(device)(*x, *args, **kwargs)
     except Exception:
-        print(f"Failed to run torchsummary, printing sizes of executed layers: {summary_list}")
+        print(
+            "Failed to run torchsummary, printing sizes of executed layers: {}".format(summary_list)
+        )
         raise
     finally:
         for hook in hooks:


### PR DESCRIPTION
Hello,

This PR re-introduce Python 3.5. Only f-string are a problem, type annotations can work just fine except inline variable declaration which have to be converted to a "# type" comment (also work perfectly fine with MyPy).
I hope this more minimal change will convince you to keep 3.5 compat for the moment :-)

Regards, Adam.

PS: Test running with 3.5 with this patch, slightly modified to apply on latest stable version:

̀```
I: pybuild base:184: cd /root/torch-summary-1.2.0+3.5/.pybuild/pythonX.Y_3.5/build; python3.5 -m pytest -v  -k"-test_frozen_layers_out -test_resnet_out -test_lstm_out"
============================= test session starts ==============================
platform linux -- Python 3.5.3, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/bin/python3.5
cachedir: ../../../.cache
rootdir: /root/torch-summary-1.2.0+3.5, inifile: 
collecting ... collected 25 items

unit_test/output_test.py::TestOutputString::test_single_input PASSED
unit_test/output_test.py::TestOutputString::test_single_input_with_kernel_macs PASSED
unit_test/output_test.py::TestOutputString::test_exception_output PASSED
unit_test/torchsummary_test.py::TestModels::test_string_result PASSED
unit_test/torchsummary_test.py::TestModels::test_single_input PASSED
unit_test/torchsummary_test.py::TestModels::test_input_tensor PASSED
unit_test/torchsummary_test.py::TestModels::test_single_layer_network PASSED
unit_test/torchsummary_test.py::TestModels::test_single_layer_network_on_gpu PASSED
unit_test/torchsummary_test.py::TestModels::test_multiple_input_types PASSED
unit_test/torchsummary_test.py::TestModels::test_lstm PASSED
unit_test/torchsummary_test.py::TestModels::test_recursive PASSED
unit_test/torchsummary_test.py::TestModels::test_model_with_args PASSED
unit_test/torchsummary_test.py::TestModels::test_resnet PASSED
unit_test/torchsummary_test.py::TestModels::test_input_size_possibilities PASSED
unit_test/torchsummary_test.py::TestModels::test_multiple_input_tensor_args PASSED
unit_test/torchsummary_test.py::TestModels::test_multiple_input_tensor_list PASSED
unit_test/torchsummary_test.py::TestModels::test_siamese_net PASSED
unit_test/torchsummary_test.py::TestModels::test_functional_layers PASSED
unit_test/torchsummary_test.py::TestModels::test_device PASSED
unit_test/torchsummary_test.py::TestModels::test_return_dict PASSED
unit_test/torchsummary_test.py::TestModels::test_exceptions PASSED
unit_test/torchsummary_test.py::TestModels::test_pack_padded PASSED
```

LSTM out test disable, it seems there's an ordered dict issue (Python 3.5 does not keep insertion order when iterating, 3.6 does, 3.7 made it a feature).
The two other output test being disabled probably comes from my torch/torchvision versions because it was already failing before the patch.

Best regards, Adam.