### PR TITLE
Add support for ModuleList and Sequentials

### DIFF
--- a/fixtures/models.py
+++ b/fixtures/models.py
@@ -257,8 +257,8 @@ class PackPaddedLSTM(nn.Module):
         self.dropout_layer = nn.Dropout(p=0.2)
 
     def forward(self, batch, lengths):
-        hidden1 = torch.ones(1, batch.size(-1), self.hidden_size)
-        hidden2 = torch.ones(1, batch.size(-1), self.hidden_size)
+        hidden1 = torch.ones(1, batch.size(-1), self.hidden_size, device=batch.device)
+        hidden2 = torch.ones(1, batch.size(-1), self.hidden_size, device=batch.device)
         embeds = self.embedding(batch)
         packed_input = pack_padded_sequence(embeds, lengths)
         _, (ht, _) = self.lstm(packed_input, (hidden1, hidden2))  # type: ignore

--- a/fixtures/models.py
+++ b/fixtures/models.py
@@ -266,3 +266,42 @@ class PackPaddedLSTM(nn.Module):
         output = self.hidden2out(output)
         output = F.log_softmax(output, dim=1)
         return output
+
+
+class ContainerModule(nn.Module):
+    """ Model using ModuleList. """
+
+    def __init__(self):
+        super().__init__()
+        self._layers = nn.ModuleList()
+        self._layers.append(nn.Linear(5, 5))
+        self._layers.append(ContainerChildModule())
+        self._layers.append(nn.Linear(5, 5))
+
+    def forward(self, x):
+        out = x
+        for m in self._layers:
+            out = m(out)
+        return out
+
+
+class ContainerChildModule(nn.Module):
+    """ Model using Sequential in different ways. """
+
+    def __init__(self):
+        super().__init__()
+        self._sequential = nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5))
+        self._between = nn.Linear(5, 5)
+
+    def forward(self, x):
+        # call sequential normal, call another layer, loop over sequential without call to foward
+        out = self._sequential(x)
+        out = self._between(out)
+        for l in self._sequential:
+            out = l(out)
+
+        # call sequential normal, loop over sequential without call to foward
+        out = self._sequential(x)
+        for l in self._sequential:
+            out = l(out)
+        return out

--- a/torchsummary/layer_info.py
+++ b/torchsummary/layer_info.py
@@ -39,8 +39,7 @@ class LayerInfo:
     def __repr__(self) -> str:
         if self.depth_index is None:
             return "{}: {}".format(self.class_name, self.depth)
-        else:
-            return "{}: {}-{}".format(self.class_name, self.depth, self.depth_index)
+        return "{}: {}-{}".format(self.class_name, self.depth, self.depth_index)
 
     def calculate_output_size(self, outputs: DETECTED_OUTPUT_TYPES, batch_dim: int) -> None:
         """ Set output_size using the model's outputs. """

--- a/torchsummary/layer_info.py
+++ b/torchsummary/layer_info.py
@@ -1,5 +1,6 @@
 """ layer_info.py """
-from typing import Any, Dict, List, Sequence, Union
+from __future__ import annotations
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -11,7 +12,7 @@ DETECTED_OUTPUT_TYPES = Union[Sequence[Any], Dict[Any, torch.Tensor], torch.Tens
 class LayerInfo:
     """ Class that holds information about a layer module. """
 
-    def __init__(self, module: nn.Module, depth: int, depth_index: int):
+    def __init__(self, module: nn.Module, depth: int, depth_index: int, parent_info: Optional[LayerInfo] = None):
         # Identifying information
         self.layer_id = id(module)
         self.module = module
@@ -19,6 +20,8 @@ class LayerInfo:
         self.inner_layers = {}  # type: Dict[str, List[int]]
         self.depth = depth
         self.depth_index = depth_index
+        self.called = False
+        self.parent_info = parent_info
 
         # Statistics
         self.trainable = True

--- a/torchsummary/layer_info.py
+++ b/torchsummary/layer_info.py
@@ -12,7 +12,7 @@ DETECTED_OUTPUT_TYPES = Union[Sequence[Any], Dict[Any, torch.Tensor], torch.Tens
 class LayerInfo:
     """ Class that holds information about a layer module. """
 
-    def __init__(self, module: nn.Module, depth: int, depth_index: int, parent_info: Optional[LayerInfo] = None):
+    def __init__(self, module: nn.Module, depth: int, depth_index: Optional[int] = None, parent_info: Optional[LayerInfo] = None):
         # Identifying information
         self.layer_id = id(module)
         self.module = module
@@ -20,7 +20,7 @@ class LayerInfo:
         self.inner_layers = {}  # type: Dict[str, List[int]]
         self.depth = depth
         self.depth_index = depth_index
-        self.called = False
+        self.executed = False
         self.parent_info = parent_info
 
         # Statistics
@@ -32,7 +32,10 @@ class LayerInfo:
         self.macs = 0
 
     def __repr__(self) -> str:
-        return "{}: {}-{}".format(self.class_name, self.depth, self.depth_index)
+        if self.depth_index is None:
+            return "{}: {}".format(self.class_name, self.depth)
+        else:
+            return "{}: {}-{}".format(self.class_name, self.depth, self.depth_index)
 
     def calculate_output_size(self, outputs: DETECTED_OUTPUT_TYPES, batch_dim: int) -> None:
         """ Set output_size using the model's outputs. """

--- a/torchsummary/layer_info.py
+++ b/torchsummary/layer_info.py
@@ -1,6 +1,4 @@
 """ layer_info.py """
-from __future__ import annotations
-
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
@@ -18,7 +16,7 @@ class LayerInfo:
         module: nn.Module,
         depth: int,
         depth_index: Optional[int] = None,
-        parent_info: Optional[LayerInfo] = None,
+        parent_info: Optional["LayerInfo"] = None,
     ):
         # Identifying information
         self.layer_id = id(module)

--- a/torchsummary/layer_info.py
+++ b/torchsummary/layer_info.py
@@ -1,5 +1,6 @@
 """ layer_info.py """
 from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
@@ -12,7 +13,13 @@ DETECTED_OUTPUT_TYPES = Union[Sequence[Any], Dict[Any, torch.Tensor], torch.Tens
 class LayerInfo:
     """ Class that holds information about a layer module. """
 
-    def __init__(self, module: nn.Module, depth: int, depth_index: Optional[int] = None, parent_info: Optional[LayerInfo] = None):
+    def __init__(
+        self,
+        module: nn.Module,
+        depth: int,
+        depth_index: Optional[int] = None,
+        parent_info: Optional[LayerInfo] = None,
+    ):
         # Identifying information
         self.layer_id = id(module)
         self.module = module

--- a/torchsummary/model_statistics.py
+++ b/torchsummary/model_statistics.py
@@ -138,7 +138,7 @@ class ModelStatistics:
     def _layer_tree_to_str(self) -> str:
         """ Print each layer of the model using a fancy branching diagram. """
         new_str = ""
-        current_hierarchy: Dict[int, LayerInfo] = {}
+        current_hierarchy = {}  # type: Dict[int, LayerInfo]
 
         for layer_info in self.summary_list:
             if layer_info.depth > self.formatting.max_depth:

--- a/torchsummary/model_statistics.py
+++ b/torchsummary/model_statistics.py
@@ -1,6 +1,5 @@
 """ model_statistics.py """
-from collections import defaultdict
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -139,8 +138,8 @@ class ModelStatistics:
     def _layer_tree_to_str(self) -> str:
         """ Print each layer of the model using a fancy branching diagram. """
         new_str = ""
-        current_hierarchy = defaultdict(lambda: None)
-            
+        current_hierarchy: Dict[int, LayerInfo] = {}
+
         for layer_info in self.summary_list:
             if layer_info.depth > self.formatting.max_depth:
                 continue
@@ -151,17 +150,20 @@ class ModelStatistics:
             while parent_info is not None and parent_info.depth > 0:
                 hierarchy[parent_info.depth] = parent_info
                 parent_info = parent_info.parent_info
-            
+
             # show hierarchy if it is not there already
             for d in range(1, layer_info.depth):
-                if d not in current_hierarchy or current_hierarchy[d].module is not hierarchy[d].module:
+                if (
+                    d not in current_hierarchy
+                    or current_hierarchy[d].module is not hierarchy[d].module
+                ):
                     new_str += self.layer_info_to_row(hierarchy[d])
                     current_hierarchy[d] = hierarchy[d]
-            
+
             reached_max_depth = layer_info.depth == self.formatting.max_depth
             new_str += self.layer_info_to_row(layer_info, reached_max_depth)
             current_hierarchy[layer_info.depth] = layer_info
-            
+
             # remove deeper hierarchy
             d = layer_info.depth + 1
             while d in current_hierarchy:

--- a/torchsummary/model_statistics.py
+++ b/torchsummary/model_statistics.py
@@ -140,25 +140,32 @@ class ModelStatistics:
         """ Print each layer of the model using a fancy branching diagram. """
         new_str = ""
         current_hierarchy = defaultdict(lambda: None)
-
+            
         for layer_info in self.summary_list:
             if layer_info.depth > self.formatting.max_depth:
                 continue
 
+            # create full hierarchy of current layer
             hierarchy = {}
             parent_info = layer_info.parent_info
             while parent_info is not None and parent_info.depth > 0:
                 hierarchy[parent_info.depth] = parent_info
                 parent_info = parent_info.parent_info
             
+            # show hierarchy if it is not there already
             for d in range(1, layer_info.depth):
-                if current_hierarchy[d] is not hierarchy[d]:
+                if d not in current_hierarchy or current_hierarchy[d].module is not hierarchy[d].module:
                     new_str += self.layer_info_to_row(hierarchy[d])
                     current_hierarchy[d] = hierarchy[d]
             
-            if current_hierarchy[layer_info.depth] is not layer_info:
-                reached_max_depth = layer_info.depth == self.formatting.max_depth
-                new_str += self.layer_info_to_row(layer_info, reached_max_depth)
-                current_hierarchy[layer_info.depth] = layer_info
+            reached_max_depth = layer_info.depth == self.formatting.max_depth
+            new_str += self.layer_info_to_row(layer_info, reached_max_depth)
+            current_hierarchy[layer_info.depth] = layer_info
+            
+            # remove deeper hierarchy
+            d = layer_info.depth + 1
+            while d in current_hierarchy:
+                current_hierarchy.pop(d)
+                d += 1
 
         return new_str

--- a/torchsummary/model_statistics.py
+++ b/torchsummary/model_statistics.py
@@ -141,6 +141,7 @@ class ModelStatistics:
             return ""
         new_left = left - 1
         new_str = ""
+        last_parent_info = None
         if right is None:
             right = len(self.summary_list)
         for i in range(left, right):
@@ -149,5 +150,11 @@ class ModelStatistics:
                 reached_max_depth = depth == self.formatting.max_depth
                 new_str += self.layer_info_to_row(layer_info, reached_max_depth)
                 new_str += self._layer_tree_to_str(new_left + 1, i, depth + 1)
+                new_left = i
+            elif not layer_info.parent_info.called:
+                if last_parent_info is None or layer_info.parent_info is not last_parent_info:
+                    new_str += self.layer_info_to_row(layer_info.parent_info)
+                    last_parent_info = layer_info.parent_info
+                new_str += self._layer_tree_to_str(new_left + 1, i+1, depth + 1)
                 new_left = i
         return new_str

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -200,7 +200,7 @@ def apply_hooks(
 ) -> None:
     """ Recursively adds hooks to all layers of the model. """
     fallback_info = LayerInfo(module, curr_depth, None, parent_info)  # if layer is not called
-    info = LayerInfo(module, curr_depth, None, parent_info)  # only define it for type checking
+    info = fallback_info  # only define it for type checking
 
     def pre_hook(module: nn.Module, inputs: Any) -> None:
         """ Create a LayerInfo object to aggregate information about that layer. """
@@ -214,7 +214,7 @@ def apply_hooks(
 
     def hook(module: nn.Module, inputs: Any, outputs: Any) -> None:
         """ Update LayerInfo after forward pass. """
-        del inputs
+        del module, inputs
         info.calculate_output_size(outputs, batch_dim)
         info.calculate_num_params()
         info.executed = True

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -125,7 +125,9 @@ def summary(
             _ = model.to(device)(*x, *args, **kwargs)
     except Exception:
         print(
-            "Failed to run torchsummary, printing sizes of executed layers: {}".format([l for l in summary_list if l.executed])
+            "Failed to run torchsummary, printing sizes of executed layers: {}".format(
+                [l for l in summary_list if l.executed]
+            )
         )
         raise
     finally:
@@ -194,11 +196,12 @@ def apply_hooks(
     idx: Dict[int, int],
     batch_dim: int,
     curr_depth: int = 0,
-    parent_info: Optional[LayerInfo] = None
+    parent_info: Optional[LayerInfo] = None,
 ) -> None:
     """ Recursively adds hooks to all layers of the model. """
-    info = LayerInfo(module, curr_depth, None, parent_info)
-    
+    fallback_info = LayerInfo(module, curr_depth, None, parent_info)  # if layer is not called
+    info = LayerInfo(module, curr_depth, None, parent_info)  # only define it for type checking
+
     def pre_hook(module: nn.Module, inputs: Any) -> None:
         """ Create a LayerInfo object to aggregate information about that layer. """
         del inputs
@@ -225,5 +228,13 @@ def apply_hooks(
     if curr_depth <= depth:
         for child in module.children():
             apply_hooks(
-                child, orig_model, depth, summary_list, hooks, idx, batch_dim, curr_depth + 1, info
+                child,
+                orig_model,
+                depth,
+                summary_list,
+                hooks,
+                idx,
+                batch_dim,
+                curr_depth + 1,
+                fallback_info,
             )

--- a/torchsummary/torchsummary.py
+++ b/torchsummary/torchsummary.py
@@ -125,7 +125,7 @@ def summary(
             _ = model.to(device)(*x, *args, **kwargs)
     except Exception:
         print(
-            "Failed to run torchsummary, printing sizes of executed layers: {}".format(summary_list)
+            "Failed to run torchsummary, printing sizes of executed layers: {}".format([l for l in summary_list if l.executed])
         )
         raise
     finally:
@@ -197,21 +197,29 @@ def apply_hooks(
     parent_info: Optional[LayerInfo] = None
 ) -> None:
     """ Recursively adds hooks to all layers of the model. """
-    idx[curr_depth] = idx.get(curr_depth, 0) + 1
-    info = LayerInfo(module, curr_depth, idx[curr_depth], parent_info)
+    info = LayerInfo(module, curr_depth, None, parent_info)
+    
+    def pre_hook(module: nn.Module, inputs: Any) -> None:
+        """ Create a LayerInfo object to aggregate information about that layer. """
+        del inputs
+        nonlocal info
+        idx[curr_depth] = idx.get(curr_depth, 0) + 1
+        info = LayerInfo(module, curr_depth, idx[curr_depth], parent_info)
+        info.depth_index = idx[curr_depth]
+        info.check_recursive(summary_list)
+        summary_list.append(info)
 
     def hook(module: nn.Module, inputs: Any, outputs: Any) -> None:
-        """ Create a LayerInfo object to aggregate information about that layer. """
+        """ Update LayerInfo after forward pass. """
         del inputs
         info.calculate_output_size(outputs, batch_dim)
         info.calculate_num_params()
-        info.check_recursive(summary_list)
-        info.called = True
-        summary_list.append(info)
+        info.executed = True
 
     # ignore Sequential and ModuleList and other containers
     submodules = [m for m in module.modules() if m is not orig_model]
     if module != orig_model or isinstance(module, LAYER_MODULES) or not submodules:
+        hooks.append(module.register_forward_pre_hook(pre_hook))
         hooks.append(module.register_forward_hook(hook))
 
     if curr_depth <= depth:

--- a/unit_test/output_test.py
+++ b/unit_test/output_test.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 import torchvision
 
-from fixtures.models import EdgeCaseModel, LSTMNet, SingleInputNet
+from fixtures.models import ContainerModule, EdgeCaseModel, LSTMNet, SingleInputNet
 from torchsummary.torchsummary import summary
 
 
@@ -88,6 +88,11 @@ class TestOutputString:
             summary(EdgeCaseModel(throw_error=True), (1, 28, 28))
 
         verify_output(capsys, "unit_test/test_output/exception.out")
+        
+    def test_container_output(self, capsys):
+        summary(ContainerModule(), (5,), depth=4)
+
+        verify_output(capsys, "unit_test/test_output/container.out")
 
 
 def verify_output(capsys, filename):

--- a/unit_test/test_output/container.out
+++ b/unit_test/test_output/container.out
@@ -1,0 +1,30 @@
+------------------------------------------------------------------------------------------
+Layer (type:depth-idx)                   Output Shape              Param #
+==========================================================================================
+├─ModuleList: 1                          []                        --
+|    └─Linear: 2-1                       [-1, 5]                   30
+|    └─ContainerChildModule: 2-2         [-1, 5]                   --
+|    |    └─Sequential: 3-1              [-1, 5]                   --
+|    |    |    └─Linear: 4-1             [-1, 5]                   30
+|    |    |    └─Linear: 4-2             [-1, 5]                   30
+|    |    └─Linear: 3-2                  [-1, 5]                   30
+|    |    └─Sequential: 3                []                        --
+|    |    |    └─Linear: 4-3             [-1, 5]                   (recursive)
+|    |    |    └─Linear: 4-4             [-1, 5]                   (recursive)
+|    |    └─Sequential: 3-3              [-1, 5]                   (recursive)
+|    |    |    └─Linear: 4-5             [-1, 5]                   (recursive)
+|    |    |    └─Linear: 4-6             [-1, 5]                   (recursive)
+|    |    |    └─Linear: 4-7             [-1, 5]                   (recursive)
+|    |    |    └─Linear: 4-8             [-1, 5]                   (recursive)
+|    └─Linear: 2-3                       [-1, 5]                   30
+==========================================================================================
+Total params: 150
+Trainable params: 150
+Non-trainable params: 0
+Total mult-adds (M): 0.00
+------------------------------------------------------------------------------------------
+Input size (MB): 0.00
+Forward/backward pass size (MB): 0.00
+Params size (MB): 0.00
+Estimated Total Size (MB): 0.00
+------------------------------------------------------------------------------------------

--- a/unit_test/test_output/exception.out
+++ b/unit_test/test_output/exception.out
@@ -15,4 +15,4 @@ Forward/backward pass size (MB): 0.04
 Params size (MB): 0.00
 Estimated Total Size (MB): 0.05
 --------------------------------------------------------------------------------------------------------------
-Failed to run torchsummary, printing sizes of executed layers: [Conv2d: 1-1, Identity: 2-1, LayerWithRidiculouslyLongNameAndDoesntDoAnything: 1-2]
+Failed to run torchsummary, printing sizes of executed layers: [Conv2d: 1-1, LayerWithRidiculouslyLongNameAndDoesntDoAnything: 1-2, Identity: 2-1]

--- a/unit_test/torchsummary_test.py
+++ b/unit_test/torchsummary_test.py
@@ -189,4 +189,4 @@ class TestModels:
         ]).long()
         # fmt: on
 
-        summary(PackPaddedLSTM(), x, y)
+        summary(PackPaddedLSTM(), x, y, device="cpu")

--- a/unit_test/torchsummary_test.py
+++ b/unit_test/torchsummary_test.py
@@ -7,6 +7,7 @@ import torch
 import torchvision
 
 from fixtures.models import (
+    ContainerModule,
     CustomModule,
     EdgeCaseModel,
     FunctionalNet,
@@ -190,3 +191,6 @@ class TestModels:
         # fmt: on
 
         summary(PackPaddedLSTM(), x, y)
+
+    def test_containers(self):
+        summary(ContainerModule(), (5,))

--- a/unit_test/torchsummary_test.py
+++ b/unit_test/torchsummary_test.py
@@ -189,4 +189,4 @@ class TestModels:
         ]).long()
         # fmt: on
 
-        summary(PackPaddedLSTM(), x, y, device="cpu")
+        summary(PackPaddedLSTM(), x, y)


### PR DESCRIPTION
This addresses #9. See my comment there also for some thoughts.

Basically I now store the parent hierarchy when creating the hooks and later fallback to using these if the parent has not been called already. I switched to a pre_hook, so that summary_list is in the right order. I think this simplifies the tree code.

This should work for nested modules, and independently of whether a container is called (like Sequential) or just iterated over (like ModuleList). It will not assign an id to containers which have not been called.